### PR TITLE
bpftest: allow passing one argument to run_bpftest_all

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1317,7 +1317,7 @@ run_bpftest_all() {
 
 		for sf in "${VIRTME_BUILD_DIR}/"test_progs*; do
 			if [ -x "\${sf}" ]; then
-				run_bpftest_one "\${sf}" mptcp || rc=\${?}
+				run_bpftest_one "\${sf}" "\${1:-mptcp}" || rc=\${?}
 			fi
 		done
 


### PR DESCRIPTION
This patch allows passing one argument to run_bpftest_all, enabling run of other BPF selftests besides MPTCP. When no argument is provided, MPTCP BPF selftests will run by default.

For example, 'run_loop run_bpftest_all sockmap_listen' is used to run the selftests for sockmap_listen.