### PR TITLE
kconfig: fix BOOTPARAM_HUNG_TASK_PANIC

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -588,11 +588,15 @@ gen_kconfig() {
 	kconfig+=(
 		-e PANIC_ON_OOPS
 		-e SOFTLOCKUP_DETECTOR
-		-e BOOTPARAM_SOFTLOCKUP_PANIC # instead of blocking
 		-e HARDLOCKUP_DETECTOR
-		-e BOOTPARAM_HUNG_TASK_PANIC # instead of blocking
 		-e DETECT_HUNG_TASK
-		-e BOOTPARAM_HUNG_TASK_PANIC # instead of blocking
+	)
+
+	# instead of blocking
+	VIRTME_RUN_OPTS+=(
+		--kopt softlockup_panic=1
+		--kopt nmi_watchdog=1
+		--kopt hung_task_panic=1
 	)
 
 	# Debug info for developers


### PR DESCRIPTION
Fix the following kconfig warning:

'''
 .virtme/build-debug-btf/.config:5030:warning: \
	symbol value 'y' invalid for BOOTPARAM_HUNG_TASK_PANIC
'''