### PR TITLE
virtme: mount /tmp as overlay for O_TMPFILE support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -128,7 +128,8 @@ VIRTME_RUN_OPTS=(
 	--arch "${VIRTME_ARCH}"
 	--name "${INPUT_HOSTNAME}"
 	--mods=auto
-	--rw # Don't use "rwdir", it will use 9p ; in a container, we can use rw
+	--rw                 # "rwdir" will use 9p ; in a container, use "rw"
+	--overlay-rwdir /tmp # to support O_TMPFILE feature
 	--pwd
 	--server --port "${INPUT_VSOCK_CID}" # To connect to the VM using VSock
 	--show-command


### PR DESCRIPTION
When running TLS tests in the mptcp upstream virtme docker environment, they fail in test_mutliproc():

```
 # tls.c:1479:mutliproc_even: Expected fd (-1) >= 0 (0)
 # mutliproc_even: Test terminated by assertion
 #          FAIL  tls.12_aes_gcm.mutliproc_even
 not ok 59 tls.12_aes_gcm.mutliproc_even
 #  RUN           tls.12_aes_gcm.mutliproc_readers ...
 # tls.c:1479:mutliproc_readers: Expected fd (-1) >= 0 (0)
 # mutliproc_readers: Test terminated by assertion
 #          FAIL  tls.12_aes_gcm.mutliproc_readers
 not ok 60 tls.12_aes_gcm.mutliproc_readers
 #  RUN           tls.12_aes_gcm.mutliproc_writers ...
 # tls.c:1479:mutliproc_writers: Expected fd (-1) >= 0 (0)
 # mutliproc_writers: Test terminated by assertion
 #          FAIL  tls.12_aes_gcm.mutliproc_writers
 not ok 61 tls.12_aes_gcm.mutliproc_writers
```

This is because the /tmp directory is not mounted as a tmpfs filesystem; it is merely a virtiofs directory, which does not support the O_TMPFILE feature.

To fix this, this patch adds '--overlay-rwdir /tmp' to the virtme-run options, ensuring that /tmp is mounted as an overlay filesystem within the virtual machine.