### PR TITLE
docker: fix byobu configure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN cd /opt && \
 	tar xzf byobu.tar.gz && \
 	cd byobu-*/ && \
 		./autogen.sh && \
-		./configure --prefix=/usr && \
+		./configure --prefix=/usr --sysconfdir=/etc && \
 		make -j"$(nproc)" -l"$(nproc)" && \
 		make install
 


### PR DESCRIPTION
The system configuration files of byobu should be installed under /etc/ rather than /usr/etc. To fix this, add '--sysconfdir=/etc' during the configure step.