### PR TITLE
run_frozen: cache script body, ignore later edits

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1458,6 +1458,58 @@ run_loop() {
 	run_loop_n 0 "\${@}"
 }
 
+# $1: source script path ; stdout: inlined content
+# Recursively inline any sibling/parent .sh library referenced via a
+# leading ". ... <lib>.sh ..." or "source <path>" line.
+freeze_script() {
+	local src="\${1}" dir lib_relpath lib_path bn
+	dir=\$(dirname "\${src}")
+	bn=\$(basename "\${src}")
+
+	lib_relpath=\$(grep -m1 -E '^[[:space:]]*(\.|source)[[:space:]]+' "\${src}" 2>/dev/null |
+		sed -nE 's@^.*"([^"]+)"?[[:space:]]*\$@\1@p' |
+		sed -E 's@^\)/@@')
+
+	if [ -n "\${lib_relpath}" ]; then
+		if [ "\${lib_relpath#*/}" != "\${lib_relpath}" ]; then
+			local _try_base="\${lib_relpath#*/}"
+			local _try_dir="\${dir}"
+			while [ -n "\${_try_dir}" ]; do
+				if [ -f "\${_try_dir}/\${_try_base}" ]; then
+					lib_path="\${_try_dir}/\${_try_base}"
+					break
+				fi
+				[ "\${_try_dir%/*}" = "\${_try_dir}" ] && break
+				_try_dir="\${_try_dir%/*}"
+			done
+		fi
+
+		# Resolve relative "../foo" by walking up from dir.
+		if [ -z "\${lib_path:-}" ]; then
+			case "\${lib_relpath}" in
+			/*) lib_path="\${lib_relpath}" ;;
+			../*)
+				local rest="\${lib_relpath}"
+				lib_path="\${dir}"
+				while [[ "\${rest}" = ../* ]]; do
+					lib_path="\${lib_path%/*}"
+					rest="\${rest#../}"
+				done
+				lib_path="\${lib_path}/\${rest}"
+				;;
+			*) lib_path="\${dir}/\${lib_relpath}" ;;
+			esac
+		fi
+
+		if [ -n "\${lib_path:-}" ] && [ -f "\${lib_path}" ]; then
+			freeze_script "\${lib_path}"
+			printf '%s\n' "# frozen: \$(basename "\${lib_path}") inlined above"
+		fi
+	fi
+
+	sed -E 's@^[[:space:]]*(\.|source)[[:space:]]+.*\$@@' "\${src}"
+}
+
 # $1: bn (script basename) ; $2: content ;
 # $3+: extra args passed to the script.
 frozen_iter() {
@@ -1480,8 +1532,9 @@ frozen_iter() {
 }
 
 # Like run_loop but reads the script body
+# with all referenced libraries inlined
 # once into memory. Later edits to the script
-# are ignored.
+# and its sibling libraries are ignored.
 run_frozen() {
 	local src content bn arg
 
@@ -1502,8 +1555,9 @@ run_frozen() {
 	fi
 
 	# capture the script body
+	# with all referenced libraries recursively inlined above it
 	bn=\$(basename "\${src}")
-	content=\$(cat "\${src}")
+	content=\$(freeze_script "\${src}")
 
 	# slice off every arg after the script as extra.
 	local extra=() i

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1408,9 +1408,13 @@ gcov_extract() {
 	fi
 }
 
-# \$1: max iterations (<1 means no limit) ; args: what needs to be executed
+# \$1: max iterations (<1 means no limit) ;
+# \$2: function to invoke once per iteration ;
+# \$3+: args passed to that function
 run_loop_n() { local i tdir rc=0
 	n=\${1}
+	fn=\${2}
+	shift
 	shift
 
 	tdir="${KERNEL_SRC}/${SELFTESTS_DIR}"
@@ -1423,7 +1427,7 @@ run_loop_n() { local i tdir rc=0
 	while true; do
 		echo -e "\n\n\t=== ${COLOR_BLUE}Attempt: \${i} (\$(date -R))${COLOR_RESET} ===\n\n"
 
-		if ! "\${@}" || has_call_trace; then
+		if ! "\${fn}" "\${@}" || has_call_trace; then
 			rc=1
 
 			echo -e "\n\n\t=== ${COLOR_RED}ERROR after \${i} attempts (\$(date -R))${COLOR_RESET} ===\n\n"
@@ -1452,6 +1456,65 @@ run_loop_n() { local i tdir rc=0
 # args: what needs to be executed
 run_loop() {
 	run_loop_n 0 "\${@}"
+}
+
+# $1: bn (script basename) ; $2: content ;
+# $3+: extra args passed to the script.
+frozen_iter() {
+	local bn=\${1} content=\${2}
+	shift 2
+	local extra=("\${@}")
+	local tdir="${KERNEL_SRC}/${SELFTESTS_DIR}"
+	local tap_bn="selftest_\${bn:0:-3}"
+	local tap_file="${RESULTS_DIR}/\${tap_bn}.tap"
+
+	log_section_start "Selftest Test: \${bn}\${extra[@]:+ \${extra[*]}}"
+	( cd "\${tdir}" && _run_selftest_one_tap "${RESULTS_DIR}/\${tap_bn}" \
+		exec -a "./\${bn}" bash -s "\${extra[@]}" ) <<<"\${content}"
+	log_section_end
+
+	if [ -s "\${tap_file}" ] && grep -q "^not ok" "\${tap_file}"; then
+		return 1
+	fi
+	return 0
+}
+
+# Like run_loop but reads the script body
+# once into memory. Later edits to the script
+# are ignored.
+run_frozen() {
+	local src content bn arg
+
+	# find the first arg that is an existing file (script).
+	for arg in "\${@}"; do
+		if [ -f "\${arg}" ]; then
+			src="\${arg}"
+			break
+		elif [ -f "${KERNEL_SRC}/${SELFTESTS_DIR}/\${arg#./}" ]; then
+			src="${KERNEL_SRC}/${SELFTESTS_DIR}/\${arg#./}"
+			break
+		fi
+	done
+
+	if [ -z "\${src}" ]; then
+		echo "run_frozen: no script file found in args" >&2
+		return 1
+	fi
+
+	# capture the script body
+	bn=\$(basename "\${src}")
+	content=\$(cat "\${src}")
+
+	# slice off every arg after the script as extra.
+	local extra=() i
+	for ((i=1; i<=\${#@}; i++)); do
+		if [ "\${!i}" = "\${src}" ] || [ "\${!i}" = "\${arg}" ]; then
+			break
+		fi
+	done
+	extra=("\${@:\$((i+1))}")
+
+	run_loop_n 0 frozen_iter "\${bn}" "\${content}" "\${extra[@]}"
 }
 
 # args: what needs to be executed


### PR DESCRIPTION
Like run_loop, but reads the first script-file argument once into memory on the first iteration, then re-runs the captured body on every retry. Later edits to the source file are ignored.

Motivation: when iterating on a test script under run_loop, every retry re-reads the file, so a developer has to finish editing before the next retry sees the change. With this variant the script body is locked at first read, which decouples test execution from concurrent edits to the file on disk.

Drop-in for run_loop on the call site:

	run_frozen run_selftest_one ./mptcp_connect.sh ARG...